### PR TITLE
Feature/allow not setting convergence criteria

### DIFF
--- a/tests/solvers/test_dense_solver.py
+++ b/tests/solvers/test_dense_solver.py
@@ -346,10 +346,21 @@ def test_convergence_criteria_existence():
     try:
         FUGWSolver(
             nits_bcd=1,
-            tol_bcd=1,
-            tol_loss=1,
-            nits_uot=None,
+            tol_bcd=None,
+            tol_loss=None,
+            nits_uot=1,
             tol_uot=None,
+        )
+    except Exception as e:
+        assert False, f"Solver should not raise exception {e}"
+
+    try:
+        FUGWSolver(
+            nits_bcd=None,
+            tol_bcd=1,
+            tol_loss=None,
+            nits_uot=None,
+            tol_uot=1,
         )
     except Exception as e:
         assert False, f"Solver should not raise exception {e}"

--- a/tests/solvers/test_dense_solver.py
+++ b/tests/solvers/test_dense_solver.py
@@ -46,7 +46,7 @@ def test_dense_solvers(solver, callback):
         nits_uot=1000,
         tol_bcd=1e-7,
         tol_uot=1e-7,
-        early_stopping_threshold=1e-5,
+        tol_loss=1e-5,
         eval_bcd=eval_bcd,
         eval_uot=10,
         ibpp_eps_base=1e2,
@@ -161,7 +161,7 @@ def test_dense_solvers_l2(reg_mode):
         nits_uot=1000,
         tol_bcd=1e-7,
         tol_uot=1e-7,
-        early_stopping_threshold=1e-5,
+        tol_loss=1e-5,
         eval_bcd=eval_bcd,
         eval_uot=10,
     )
@@ -279,7 +279,7 @@ def test_validation_solver(validation):
         nits_uot=1000,
         tol_bcd=1e-7,
         tol_uot=1e-7,
-        early_stopping_threshold=1e-5,
+        tol_loss=1e-5,
         eval_bcd=eval_bcd,
         eval_uot=10,
         ibpp_eps_base=1e2,
@@ -318,3 +318,38 @@ def test_validation_solver(validation):
         "total",
     ]:
         assert len(loss_val[key]) == len(loss_steps)
+
+
+def test_convergence_criteria_existence():
+    with pytest.raises(
+        ValueError, match="At least one of .* must be provided"
+    ):
+        FUGWSolver(
+            nits_bcd=None,
+            tol_bcd=None,
+            tol_loss=None,
+            nits_uot=1,
+            tol_uot=1,
+        )
+
+    with pytest.raises(
+        ValueError, match="At least one of .* must be provided"
+    ):
+        FUGWSolver(
+            nits_bcd=1,
+            tol_bcd=1,
+            tol_loss=1,
+            nits_uot=None,
+            tol_uot=None,
+        )
+
+    try:
+        FUGWSolver(
+            nits_bcd=1,
+            tol_bcd=1,
+            tol_loss=1,
+            nits_uot=None,
+            tol_uot=None,
+        )
+    except Exception as e:
+        assert False, f"Solver should not raise exception {e}"

--- a/tests/solvers/test_sparse_solver.py
+++ b/tests/solvers/test_sparse_solver.py
@@ -58,7 +58,7 @@ def test_sparse_solvers(solver, device, callback):
         nits_uot=1000,
         tol_bcd=1e-7,
         tol_uot=1e-7,
-        early_stopping_threshold=1e-5,
+        tol_loss=1e-5,
         eval_bcd=eval_bcd,
         eval_uot=10,
         # Set a high value of ibpp, otherwise nans appear in coupling.
@@ -226,7 +226,7 @@ def test_sparse_validation_solver(validation, device):
         nits_uot=1000,
         tol_bcd=1e-7,
         tol_uot=1e-7,
-        early_stopping_threshold=1e-5,
+        tol_loss=1e-5,
         eval_bcd=eval_bcd,
         eval_uot=10,
         # Set a high value of ibpp, otherwise nans appear in coupling.
@@ -267,3 +267,38 @@ def test_sparse_validation_solver(validation, device):
         "total",
     ]:
         assert len(loss_val[key]) == len(loss_steps)
+
+
+def test_convergence_criteria_existence():
+    with pytest.raises(
+        ValueError, match="At least one of .* must be provided"
+    ):
+        FUGWSparseSolver(
+            nits_bcd=None,
+            tol_bcd=None,
+            tol_loss=None,
+            nits_uot=1,
+            tol_uot=1,
+        )
+
+    with pytest.raises(
+        ValueError, match="At least one of .* must be provided"
+    ):
+        FUGWSparseSolver(
+            nits_bcd=1,
+            tol_bcd=1,
+            tol_loss=1,
+            nits_uot=None,
+            tol_uot=None,
+        )
+
+    try:
+        FUGWSparseSolver(
+            nits_bcd=1,
+            tol_bcd=1,
+            tol_loss=1,
+            nits_uot=None,
+            tol_uot=None,
+        )
+    except Exception as e:
+        assert False, f"Solver should not raise exception {e}"

--- a/tests/solvers/test_sparse_solver.py
+++ b/tests/solvers/test_sparse_solver.py
@@ -295,10 +295,21 @@ def test_convergence_criteria_existence():
     try:
         FUGWSparseSolver(
             nits_bcd=1,
-            tol_bcd=1,
-            tol_loss=1,
-            nits_uot=None,
+            tol_bcd=None,
+            tol_loss=None,
+            nits_uot=1,
             tol_uot=None,
+        )
+    except Exception as e:
+        assert False, f"Solver should not raise exception {e}"
+
+    try:
+        FUGWSparseSolver(
+            nits_bcd=None,
+            tol_bcd=1,
+            tol_loss=None,
+            nits_uot=None,
+            tol_uot=1,
         )
     except Exception as e:
         assert False, f"Solver should not raise exception {e}"


### PR DESCRIPTION
Rename `early_stopping_threshold` to `tol_loss`.
Allow setting only `nits_*` or `tol_*` and raise exception when both are not set.
Add tests.