### PR TITLE
Deprecate python 3.7 and bump python test version for macos

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version_python: "3.7"
-          - os: ubuntu-latest
             version_python: "3.8"
           - os: ubuntu-latest
             version_python: "3.9"
@@ -26,7 +24,7 @@ jobs:
           - os: ubuntu-latest
             version_python: "3.11"
           - os: macos-latest
-            version_python: "3.7"
+            version_python: "3.10"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Deprecate testing python 3.7.