### PR TITLE
[Hotfix] Remove useless print statement

### DIFF
--- a/src/fugw/solvers/utils.py
+++ b/src/fugw/solvers/utils.py
@@ -809,7 +809,7 @@ def solver_mm_l2_sparse(
                 + eps * pi_values_prev
                 + 1e-16
             )
-            print(torch.count_nonzero(denom_values == 0))
+
             pi_values = thres_values * pi_values_prev / denom_values
 
             # Efficiently compute sum on rows


### PR DESCRIPTION
Removes a useless print statement as ``denom_values`` is defined in such a way that it is at least ``1e-16``. Otherwise ``tensor(0, device='cuda:0')``  ends up appearing everywhere when using the mm L2 solver thus clogging log files.