### PR TITLE
Adjust rho_fine for sparse surfacic example

### DIFF
--- a/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
+++ b/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
@@ -267,7 +267,7 @@ coarse_mapping_solver_params = {
 }
 
 alpha_fine = 0.5
-rho_fine = 1
+rho_fine = 1e-2
 eps_fine = 1e-4
 fine_mapping = FUGWSparse(alpha=alpha_fine, rho=rho_fine, eps=eps_fine)
 fine_mapping_solver = "mm"


### PR DESCRIPTION
Short PR to improve the training loss plot in the coarse-to-fine example. For demonstration purposes, I think it is better to show a more _"balanced"_ example.

Before :
<img width="620" alt="image" src="https://github.com/alexisthual/fugw/assets/104081777/d4376c49-8c77-47ee-b234-88e6df567609">

After :
<img width="620" alt="image" src="https://github.com/alexisthual/fugw/assets/104081777/3c5c2482-7f6c-4d7f-a33e-b1995c523eca">