### PR TITLE
[Feat] Add the option to interpolate the transport plan with the identity

### DIFF
--- a/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
+++ b/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
@@ -689,7 +689,7 @@ plt.show()
 # %%
 # We can also partially transport feature maps, by specifying
 # a parameter ``id_reg`` which balances the amount of regularization
-# applied between the tarnsport plan and the identity mapping. The
+# applied between the transport plan and the identity mapping. The
 # regularized transport plan is then ``id_reg`` times the identity
 # plus ``(1 - id_reg)`` times the transport plan computed by FUGW.
 

--- a/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
+++ b/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
@@ -685,3 +685,53 @@ plot_surface_map(
 )
 
 plt.show()
+
+# %%
+# We can also partially transport feature maps, by specifying
+# a parameter ``id_reg`` which balances the amount of regularization
+# applied between the tarnsport plan and the identity mapping. The
+# regularized transport plan is then ``id_reg`` times the identity
+# plus ``(1 - id_reg)`` times the transport plan computed by FUGW.
+
+# Set of weights for the regularization parameter
+id_reg = 1 - np.linspace(0, 1, 3)
+
+fig = plt.figure(figsize=(3 * 5, 4))
+fig.suptitle(
+    "Partial transportation of the feature maps by\nregularizing the transport"
+    " plan with the identity"
+)
+grid_spec = gridspec.GridSpec(1, 5, figure=fig)
+
+ax = fig.add_subplot(grid_spec[0, 0], projection="3d")
+ax.set_title("Actual source features")
+plot_surface_map(
+    source_features[contrast_index, :],
+    axes=ax,
+    vmax=10,
+    vmin=-10,
+    colorbar=False,
+)
+
+for i in range(len(id_reg)):
+    predicted_target_features = fine_mapping.transform(
+        source_features[contrast_index, :],
+        id_reg=id_reg[i],
+    )
+    ax = fig.add_subplot(grid_spec[0, i + 1], projection="3d")
+    ax.set_title(f"id_reg={id_reg[i]}")
+    plot_surface_map(
+        predicted_target_features, axes=ax, vmax=10, vmin=-10, colorbar=False
+    )
+
+ax = fig.add_subplot(grid_spec[0, -1], projection="3d")
+ax.set_title("Actual target features")
+plot_surface_map(
+    target_features[contrast_index, :],
+    axes=ax,
+    vmax=10,
+    vmin=-10,
+    colorbar=False,
+)
+
+plt.show()

--- a/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
+++ b/examples/01_brain_alignment/plot_2_aligning_brain_sparse.py
@@ -694,7 +694,7 @@ plt.show()
 # plus ``(1 - id_reg)`` times the transport plan computed by FUGW.
 
 # Set of weights for the regularization parameter
-id_reg = 1 - np.linspace(0, 1, 3)
+id_reg = [.0, .5, 1.]
 
 fig = plt.figure(figsize=(3 * 5, 4))
 fig.suptitle(

--- a/src/fugw/mappings/dense.py
+++ b/src/fugw/mappings/dense.py
@@ -279,7 +279,7 @@ class FUGW(BaseMapping):
         ----------
         source_features: ndarray(n_samples, n) or ndarray(n)
             Contrast map for source subject
-        id_reg: float, optional, defaults to 0
+        id_reg: float, in the [0, 1] interval, defaults to 0
             If source/target share the same geometry,
             interpolate the transport plan with the identity
             using the provided coefficient.

--- a/src/fugw/mappings/dense.py
+++ b/src/fugw/mappings/dense.py
@@ -328,16 +328,13 @@ class FUGW(BaseMapping):
                 )
             transformed_data = (
                 (
-                    (
-                        (1 - id_reg)
-                        * (
-                            pi.T
-                            @ source_features_tensor.T
-                            / pi.sum(dim=0).reshape(-1, 1)
-                        )
-                        + id_reg * source_features_tensor.T
+                    (1 - id_reg)
+                    * (
+                        pi.T
+                        @ source_features_tensor.T
+                        / pi.sum(dim=0).reshape(-1, 1)
                     )
-                    / 2
+                    + id_reg * source_features_tensor.T
                 )
                 .T.detach()
                 .cpu()

--- a/src/fugw/mappings/dense.py
+++ b/src/fugw/mappings/dense.py
@@ -283,6 +283,8 @@ class FUGW(BaseMapping):
             If source/target share the same geometry,
             interpolate the transport plan with the identity
             using the provided coefficient.
+            A value of 1 (resp. 0) will rely solely on the identity
+            (resp. the transport plan).
         device: "auto" or torch.device
             If "auto": use first available GPU if it's available,
             CPU otherwise.

--- a/src/fugw/mappings/dense.py
+++ b/src/fugw/mappings/dense.py
@@ -270,9 +270,7 @@ class FUGW(BaseMapping):
 
         return self
 
-    def transform(
-        self, source_features, id_interpolation=False, device="auto"
-    ):
+    def transform(self, source_features, id_reg=0, device="auto"):
         """
         Transport source feature maps using fitted OT plan.
         Use GPUs if available.
@@ -281,9 +279,10 @@ class FUGW(BaseMapping):
         ----------
         source_features: ndarray(n_samples, n) or ndarray(n)
             Contrast map for source subject
-        id_interpolation: bool, optional, defaults to False
-            If True and source/target share the same geometry,
-            interpolate the transport plan with the identity.
+        id_reg: float, optional, defaults to 0
+            If source/target share the same geometry,
+            interpolate the transport plan with the identity
+            using the provided coefficient.
         device: "auto" or torch.device
             If "auto": use first available GPU if it's available,
             CPU otherwise.
@@ -317,21 +316,26 @@ class FUGW(BaseMapping):
         source_features_tensor = _make_tensor(source_features, device=device)
 
         # Transform data
-        if id_interpolation:
+        if id_reg != 0:
             if pi.shape[0] != pi.shape[1]:
                 raise ValueError(
                     "Cannot interpolate with identity if source and target"
                     " have different geometries."
                 )
+            if id_reg < 0 or id_reg > 1:
+                raise ValueError(
+                    f"id_reg should be between 0 and 1, got {id_reg}"
+                )
             transformed_data = (
                 (
                     (
-                        (
+                        (1 - id_reg)
+                        * (
                             pi.T
                             @ source_features_tensor.T
                             / pi.sum(dim=0).reshape(-1, 1)
                         )
-                        + source_features_tensor.T
+                        + id_reg * source_features_tensor.T
                     )
                     / 2
                 )

--- a/src/fugw/mappings/sparse.py
+++ b/src/fugw/mappings/sparse.py
@@ -318,6 +318,8 @@ class FUGWSparse(BaseMapping):
             If source/target share the same geometry,
             interpolate the transport plan with the identity
             using the provided coefficient.
+            A value of 1 (resp. 0) will rely solely on the identity
+            (resp. the transport plan).
         device: "auto" or torch.device
             If "auto": use first available GPU if it's available,
             CPU otherwise.

--- a/src/fugw/mappings/sparse.py
+++ b/src/fugw/mappings/sparse.py
@@ -314,7 +314,7 @@ class FUGWSparse(BaseMapping):
         ----------
         source_features: ndarray(n_samples, n) or ndarray(n)
             Contrast map for source subject
-        id_reg: float, optional, defaults to 0
+        id_reg: float, in the [0, 1] interval, defaults to 0
             If source/target share the same geometry,
             interpolate the transport plan with the identity
             using the provided coefficient.

--- a/tests/mappings/test_dense_mapping.py
+++ b/tests/mappings/test_dense_mapping.py
@@ -213,3 +213,27 @@ def test_available_l2_solver(solver):
             target_geometry=target_geometry,
             solver=solver,
         )
+
+
+@pytest.mark.parametrize("id_reg", [-1.0, 0.0, 0.5, 1.0, 2.0])
+def test_identity_regularization(id_reg):
+    _, source_features_train, _, _ = _init_mock_distribution(
+        n_features_train, n_voxels_source, return_numpy=False
+    )
+
+    mapping = FUGW()
+    mapping.pi = torch.eye(n_voxels_source)
+
+    if id_reg < 0 or id_reg > 1:
+        with pytest.raises(
+            ValueError, match=f"id_reg should be between 0 and 1, got {id_reg}"
+        ):
+            mapping.transform(source_features_train, id_reg=id_reg)
+    else:
+        transformed_data = mapping.transform(
+            source_features_train, id_reg=id_reg
+        )
+        assert transformed_data.shape == source_features_train.shape
+        assert torch.allclose(
+            transformed_data, source_features_train, atol=1e-5
+        )


### PR DESCRIPTION
This short PR implements an option to interpolate between the transport plan and the identity (as suggested by @bthirion ) when calling the ``.transform`` method. Such interpolation has shown significant improvements in decoding performances in my recent benchmarks, I thus propose to include it directly in FUGW.