### PR TITLE
[Fix] check mkl support for failing CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import torch
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "skip_if_no_mkl: Skip test if MKL support is not available."
+    )
+
+
+@pytest.fixture(autouse=True)
+def check_mkl_availability(request):
+    if (
+        "skip_if_no_mkl" in request.keywords
+        and not torch.backends.mkl.is_available()
+    ):
+        pytest.skip("Test requires MKL support which is not available.")

--- a/tests/mappings/test_sparse_mapping.py
+++ b/tests/mappings/test_sparse_mapping.py
@@ -27,6 +27,7 @@ solvers = ["sinkhorn", "mm", "ibpp"]
 callbacks = [None, lambda x: x["gamma"]]
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "device,return_numpy,solver,callback",
     product(devices, return_numpys, solvers, callbacks),
@@ -95,6 +96,7 @@ def test_sparse_mapping(device, return_numpy, solver, callback):
     assert isinstance(target_features_on_source, torch.Tensor)
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "device,sparse_layout,return_numpy",
     product(devices, sparse_layouts, return_numpys),
@@ -163,6 +165,7 @@ def test_fugw_sparse_with_init(device, sparse_layout, return_numpy):
     assert isinstance(target_features_on_source, torch.Tensor)
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "validation", ["None", "features", "geometries", "Both"]
 )

--- a/tests/scripts/test_coarse_to_fine.py
+++ b/tests/scripts/test_coarse_to_fine.py
@@ -26,6 +26,7 @@ if torch.cuda.is_available():
 return_numpys = [False, True]
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize("return_numpy", product(return_numpys))
 def test_random_normalizing(return_numpy):
     _, _, _, embeddings = _init_mock_distribution(
@@ -53,6 +54,7 @@ def test_uniform_mesh_sampling():
     assert np.unique(sample).shape == (n_samples,)
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "device,return_numpy", product(devices, return_numpys)
 )

--- a/tests/solvers/test_sparse_solver.py
+++ b/tests/solvers/test_sparse_solver.py
@@ -18,6 +18,9 @@ alphas = [0.0, 0.5, 1.0]
 
 
 # TODO: need to test sinkhorn
+
+
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "solver,device,callback,alpha",
     product(["sinkhorn", "mm", "ibpp"], devices, callbacks, alphas),
@@ -143,6 +146,7 @@ def test_sparse_solvers(solver, device, callback, alpha):
     )
 
 
+@pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "validation,device",
     product(["None", "features", "geometries", "Both"], devices),

--- a/tests/solvers/test_sparse_solver.py
+++ b/tests/solvers/test_sparse_solver.py
@@ -18,8 +18,6 @@ alphas = [0.0, 0.5, 1.0]
 
 
 # TODO: need to test sinkhorn
-
-
 @pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize(
     "solver,device,callback,alpha",


### PR DESCRIPTION
The CI fails to install `torch` with MKL support and therefore fails when doing sparse operations, including tests.

This short PR solves the issue by adding a custom fixture that checks if MKL is installed.