### PR TITLE
[FIX] Fix save_mapping and load_mapping utils

### DIFF
--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -155,7 +155,6 @@ class FUGWBarycenter:
                 solver=solver,
                 solver_params=solver_params,
                 device=device,
-                storing_device=device,
                 verbose=verbose,
             )
 

--- a/src/fugw/mappings/dense.py
+++ b/src/fugw/mappings/dense.py
@@ -27,7 +27,6 @@ class FUGW(BaseMapping):
         solver_params={},
         callback_bcd=None,
         device="auto",
-        storing_device="cpu",
         verbose=False,
     ):
         """
@@ -101,8 +100,6 @@ class FUGW(BaseMapping):
         device: "auto" or torch.device
             if "auto": use first available gpu if it's available,
             cpu otherwise.
-        storing_device: torch.device, default="cpu"
-            Device on which to store the computed transport plan.
         verbose: bool, optional, defaults to False
             Log solving process.
 
@@ -258,7 +255,7 @@ class FUGW(BaseMapping):
         )
 
         # Store variables of interest in model
-        self.pi = res["pi"].detach().to(device=storing_device)
+        self.pi = res["pi"].detach()
         self.loss = res["loss"]
         self.loss_steps = res["loss_steps"]
         self.loss_times = res["loss_times"]

--- a/src/fugw/mappings/sparse.py
+++ b/src/fugw/mappings/sparse.py
@@ -33,7 +33,6 @@ class FUGWSparse(BaseMapping):
         solver_params={},
         callback_bcd=None,
         device="auto",
-        storing_device="cpu",
         verbose=False,
     ):
         """
@@ -107,8 +106,6 @@ class FUGWSparse(BaseMapping):
         device: "auto" or torch.device
             if "auto": use first available gpu if it's available,
             cpu otherwise.
-        storing_device: torch.device, default="cpu"
-            Device on which to store the computed transport plan.
         verbose: bool, optional, defaults to False
             Log solving process.
 
@@ -295,7 +292,7 @@ class FUGWSparse(BaseMapping):
             verbose=verbose,
         )
 
-        self.pi = res["pi"].to_sparse_coo().detach().to(device=storing_device)
+        self.pi = res["pi"].to_sparse_coo().detach()
         self.loss = res["loss"]
         self.loss_val = res["loss_val"]
         self.loss_steps = res["loss_steps"]

--- a/src/fugw/scripts/coarse_to_fine.py
+++ b/src/fugw/scripts/coarse_to_fine.py
@@ -419,6 +419,9 @@ def fit(
         verbose=verbose,
     )
 
+    # Send coarse mapping to cpu to handle numpy operations
+    coarse_mapping.pi = coarse_mapping.pi.cpu()
+
     # 2. Build sparsity mask
 
     # Select best pairs of source and target vertices from coarse alignment

--- a/src/fugw/utils.py
+++ b/src/fugw/utils.py
@@ -252,7 +252,7 @@ def init_plan_dense(
     return plan
 
 
-def save_mapping(mapping, fname, storing_device="cpu"):
+def save_mapping(mapping, fname):
     """Save mapping in pickle file, separating hyperparams and weights.
 
     Parameters
@@ -261,10 +261,8 @@ def save_mapping(mapping, fname, storing_device="cpu"):
         FUGW mapping to save
     fname: str or pathlib.Path
         Path to pickle file to save
-    storing_device: torch.device, default="cpu"
-        Device on which to store the computed transport plan.
     """
-    mapping.pi = mapping.pi.to(storing_device)
+    mapping.pi = mapping.pi.to("cpu")
     with open(fname, "wb") as f:
         # Dump hyperparams first
         pickle.dump(mapping, f)
@@ -272,7 +270,7 @@ def save_mapping(mapping, fname, storing_device="cpu"):
         pickle.dump(mapping.pi, f)
 
 
-def load_mapping(fname, load_weights=True, storing_device="cpu"):
+def load_mapping(fname, load_weights=True, device="cpu"):
     """Load mapping from pickle file, optionally loading weights.
 
     Parameters
@@ -281,7 +279,7 @@ def load_mapping(fname, load_weights=True, storing_device="cpu"):
         Path to pickle file to load
     load_weights: bool, optional, defaults to True
         If True, load mapping weights from pickle file.
-    storing_device: torch.device, default="cpu"
+    device: torch.device, default="cpu"
         Device on which to store the computed transport plan.
 
     Returns
@@ -292,6 +290,6 @@ def load_mapping(fname, load_weights=True, storing_device="cpu"):
         mapping = pickle.load(f)
         if load_weights:
             mapping.pi = pickle.load(f)
-            mapping.pi = mapping.pi.to(storing_device)
+            mapping.pi = mapping.pi.to(device)
 
     return mapping

--- a/src/fugw/utils.py
+++ b/src/fugw/utils.py
@@ -272,7 +272,7 @@ def save_mapping(mapping, fname, storing_device="cpu"):
         pickle.dump(mapping.pi, f)
 
 
-def load_mapping(fname, load_weights=True):
+def load_mapping(fname, load_weights=True, storing_device="cpu"):
     """Load mapping from pickle file, optionally loading weights.
 
     Parameters
@@ -281,6 +281,8 @@ def load_mapping(fname, load_weights=True):
         Path to pickle file to load
     load_weights: bool, optional, defaults to True
         If True, load mapping weights from pickle file.
+    storing_device: torch.device, default="cpu"
+        Device on which to store the computed transport plan.
 
     Returns
     -------
@@ -290,5 +292,6 @@ def load_mapping(fname, load_weights=True):
         mapping = pickle.load(f)
         if load_weights:
             mapping.pi = pickle.load(f)
+            mapping.pi = mapping.pi.to(storing_device)
 
     return mapping

--- a/src/fugw/utils.py
+++ b/src/fugw/utils.py
@@ -262,6 +262,7 @@ def save_mapping(mapping, fname):
     fname: str or pathlib.Path
         Path to pickle file to save
     """
+    # Move mapping weights to CPU before saving
     mapping.pi = mapping.pi.to("cpu")
     with open(fname, "wb") as f:
         # Dump hyperparams first

--- a/src/fugw/utils.py
+++ b/src/fugw/utils.py
@@ -252,7 +252,7 @@ def init_plan_dense(
     return plan
 
 
-def save_mapping(mapping, fname):
+def save_mapping(mapping, fname, storing_device="cpu"):
     """Save mapping in pickle file, separating hyperparams and weights.
 
     Parameters
@@ -261,7 +261,10 @@ def save_mapping(mapping, fname):
         FUGW mapping to save
     fname: str or pathlib.Path
         Path to pickle file to save
+    storing_device: torch.device, default="cpu"
+        Device on which to store the computed transport plan.
     """
+    mapping.pi = mapping.pi.to(storing_device)
     with open(fname, "wb") as f:
         # Dump hyperparams first
         pickle.dump(mapping, f)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,15 +117,15 @@ def test_saving_and_loading(device, return_numpy, solver):
     with TemporaryDirectory() as tmpdir:
         fname = tmpdir + "/mapping.pkl"
 
-        save_mapping(fugw, fname, device)
+        save_mapping(fugw, fname)
 
         mapping_without_weights = load_mapping(
-            fname, load_weights=False, storing_device=device
+            fname, load_weights=False, device=device
         )
         assert mapping_without_weights.pi is None
 
         mapping_with_weights = load_mapping(
-            fname, load_weights=True, storing_device=device
+            fname, load_weights=True, device=device
         )
         assert mapping_with_weights.pi.shape == (
             n_voxels_source,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,12 +117,16 @@ def test_saving_and_loading(device, return_numpy, solver):
     with TemporaryDirectory() as tmpdir:
         fname = tmpdir + "/mapping.pkl"
 
-        save_mapping(fugw, fname)
+        save_mapping(fugw, fname, device)
 
-        mapping_without_weights = load_mapping(fname, load_weights=False)
+        mapping_without_weights = load_mapping(
+            fname, load_weights=False, storing_device=device
+        )
         assert mapping_without_weights.pi is None
 
-        mapping_with_weights = load_mapping(fname, load_weights=True)
+        mapping_with_weights = load_mapping(
+            fname, load_weights=True, storing_device=device
+        )
         assert mapping_with_weights.pi.shape == (
             n_voxels_source,
             n_voxels_target,


### PR DESCRIPTION
Closes #42, closes #55. `save_mapping`  now dumps the weights on the cpu before saving and the user has the choice to pass a device when using `load_mapping`.