### PR TITLE
Fix/57 barycenter different geometries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.7"
 dependencies = [
   "dijkstra3d>=1.12.1",
   "joblib>=1.2.0",
-  "numpy>=1.20",
+  "numpy<2",
   "rich>=13.3.1",
   "POT>=0.9.0",
   "scikit-learn",

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -170,7 +170,7 @@ class FUGWSparseBarycenter:
         features_list (list of np.array): List of features. Individuals should
             have the same number of features n_features.
         geometry_embedding (np.array or torch.Tensor): Common geometry
-        embedding of all individuals and barycenter.
+            embedding of all individuals and barycenter.
         barycenter_size (int), optional:
             Size of computed barycentric features and geometry.
             Defaults to None.

--- a/tests/mappings/test_sparse_barycenter.py
+++ b/tests/mappings/test_sparse_barycenter.py
@@ -43,7 +43,7 @@ def test_fugw_barycenter(device):
     ) = fugw_barycenter.fit(
         weights_list,
         features_list,
-        [geometry_embedding],
+        geometry_embedding,
         mesh_sample=mesh_sample,
         coarse_mapping_solver_params={"nits_bcd": 2, "nits_uot": 5},
         fine_mapping_solver_params={"nits_bcd": 2, "nits_uot": 5},


### PR DESCRIPTION
Sparse barycenters now only rely on a common `geometry_embedding` which closes #57 .