### PR TITLE
[FEAT] Add caching options for geometry

### DIFF
--- a/src/fugw/datasets/__init__.py
+++ b/src/fugw/datasets/__init__.py
@@ -1,0 +1,7 @@
+from .surf_geometry import fetch_surf_geometry
+from .vol_geometry import fetch_vol_geometry
+
+__all__ = [
+    "fetch_surf_geometry",
+    "fetch_vol_geometry",
+]

--- a/src/fugw/datasets/surf_geometry.py
+++ b/src/fugw/datasets/surf_geometry.py
@@ -56,9 +56,10 @@ def _fetch_geometry_full_rank(
         geometry = distance_matrix(coordinates, coordinates)
 
     # Normalize the distance matrix
-    geometry = geometry / geometry.max()
+    d_max = geometry.max()
+    geometry = geometry / d_max
 
-    return geometry
+    return geometry, d_max
 
 
 @memory.cache

--- a/src/fugw/datasets/surf_geometry.py
+++ b/src/fugw/datasets/surf_geometry.py
@@ -16,6 +16,7 @@ memory = Memory(fugw_data, verbose=0)
 
 
 def _check_mesh(mesh: str) -> None:
+    """Check if the mesh is valid."""
     valid_meshes = ["pial_left", "pial_right", "infl_left", "infl_right"]
     if mesh not in valid_meshes:
         raise ValueError(
@@ -24,6 +25,7 @@ def _check_mesh(mesh: str) -> None:
 
 
 def _check_resolution(resolution: str) -> None:
+    """Check if the resolution is valid."""
     valid_resolutions = [
         "fsaverage3",
         "fsaverage4",
@@ -42,7 +44,10 @@ def _check_resolution(resolution: str) -> None:
 @memory.cache
 def _fetch_geometry_full_rank(
     mesh: str, resolution: str, method: str = "geodesic"
-):
+) -> Tuple[np.ndarray, float]:
+    """Returns the normalized full-rank distance matrix for the
+    given mesh and the maximum distance between two points in the mesh.
+    """
     mesh_path = datasets.fetch_surf_fsaverage(mesh=resolution)[mesh]
     (coordinates, triangles) = surface.load_surf_mesh(mesh_path)
     if method == "geodesic":
@@ -72,6 +77,9 @@ def _fetch_geometry_low_rank(
     n_jobs: int = 2,
     verbose: bool = True,
 ) -> Tuple[np.ndarray, float]:
+    """Returns the normalized low-rank distance matrix for the
+    given mesh and the maximum distance between two points in the mesh.
+    """
     if method == "euclidean":
         raise NotImplementedError(
             "Low-rank embedding is not implemented for L2 distance matrices."
@@ -103,7 +111,41 @@ def fetch_surf_geometry(
     n_landmarks: int = 100,
     n_jobs: int = 2,
     verbose: bool = True,
-):
+) -> Tuple[np.ndarray, float]:
+    """Returns either the normalized full-rank or low-rank embedding
+    of the distance matrix for the given mesh and the maximum distance
+    between two points in the mesh.
+
+    Parameters
+    ----------
+    mesh : str
+        Input mesh name. Valid meshes include "pial_left", "pial_right",
+        "infl_left", and "infl_right".
+    resolution : str
+        Input resolution name. Valid resolutions include "fsaverage3",
+        "fsaverage4", "fsaverage5", "fsaverage6", "fsaverage7", and
+        "fsaverage".
+    method : str, optional
+        Method used to compute distances, either "geodesic" or "euclidean",
+        by default "geodesic".
+    rank : int, optional
+        Dimension of embedding, -1 for full-rank embedding
+        and rank < n_vertices for low-rank embedding, by default -1
+    n_landmarks : int, optional
+        Number of vertices to sample on mesh to approximate embedding,
+        by default 100
+    n_jobs : int, optional,
+        Relative tolerance used to check intermediate results, by default 2
+    verbose : bool, optional
+        Enable logging, by default True
+
+    Returns
+    -------
+    Tuple[np.ndarray, float]
+        Full-rank or low-rank embedding of the distance matrix of size
+        (n_vertices, n_vertices) or (n_vertices, rank) and the maximum
+        distance encountered in the mesh.
+    """
     _check_mesh(mesh)
     _check_resolution(resolution)
 

--- a/src/fugw/datasets/surf_geometry.py
+++ b/src/fugw/datasets/surf_geometry.py
@@ -1,0 +1,122 @@
+import gdist
+import numpy as np
+
+from typing import Tuple
+
+from joblib import Memory
+from nilearn import surface, datasets
+from scipy.spatial import distance_matrix
+
+from fugw.scripts import coarse_to_fine, lmds
+
+
+# Create a Memory object to handle the caching
+fugw_data = "~/fugw_data"
+memory = Memory(fugw_data, verbose=0)
+
+
+def _check_mesh(mesh: str) -> None:
+    valid_meshes = ["pial_left", "pial_right", "infl_left", "infl_right"]
+    if mesh not in valid_meshes:
+        raise ValueError(
+            f"Unknown mesh {mesh}. Valid meshes include {valid_meshes}."
+        )
+
+
+def _check_resolution(resolution: str) -> None:
+    valid_resolutions = [
+        "fsaverage3",
+        "fsaverage4",
+        "fsaverage5",
+        "fsaverage6",
+        "fsaverage7",
+        "fsaverage",
+    ]
+    if resolution not in valid_resolutions:
+        raise ValueError(
+            f"Unknown resolution {resolution}. Valid resolutions include"
+            f" {valid_resolutions}."
+        )
+
+
+@memory.cache
+def _fetch_geometry_full_rank(
+    mesh: str, resolution: str, method: str = "geodesic"
+):
+    mesh_path = datasets.fetch_surf_fsaverage(mesh=resolution)[mesh]
+    (coordinates, triangles) = surface.load_surf_mesh(mesh_path)
+    if method == "geodesic":
+        # Return geodesic distance matrix
+        geometry = gdist.local_gdist_matrix(
+            coordinates.astype(np.float64), triangles.astype(np.int32)
+        ).toarray()
+
+    elif method == "euclidean":
+        # Return euclidean distance matrix
+        geometry = distance_matrix(coordinates, coordinates)
+
+    # Normalize the distance matrix
+    geometry = geometry / geometry.max()
+
+    return geometry
+
+
+@memory.cache
+def _fetch_geometry_low_rank(
+    mesh: str,
+    resolution: str,
+    method: str = "geodesic",
+    rank: int = 3,
+    n_landmarks: int = 100,
+    n_jobs: int = 2,
+    verbose: bool = True,
+) -> Tuple[np.ndarray, float]:
+    if method == "euclidean":
+        raise NotImplementedError(
+            "Low-rank embedding is not implemented for L2 distance matrices."
+        )
+
+    mesh_path = datasets.fetch_surf_fsaverage(mesh=resolution)[mesh]
+    (coordinates, triangles) = surface.load_surf_mesh(mesh_path)
+    geometry_embedding = lmds.compute_lmds_mesh(
+        coordinates,
+        triangles,
+        n_landmarks=n_landmarks,
+        k=rank,
+        n_jobs=n_jobs,
+        verbose=verbose,
+    )
+    (
+        geometry_embedding_normalized,
+        d_max,
+    ) = coarse_to_fine.random_normalizing(geometry_embedding)
+
+    return geometry_embedding_normalized.cpu().numpy(), d_max
+
+
+def fetch_surf_geometry(
+    mesh: str,
+    resolution: str,
+    method: str = "geodesic",
+    rank: int = -1,
+    n_landmarks: int = 100,
+    n_jobs: int = 2,
+    verbose: bool = True,
+):
+    _check_mesh(mesh)
+    _check_resolution(resolution)
+
+    if rank == -1:
+        return _fetch_geometry_full_rank(
+            mesh=mesh, resolution=resolution, method=method
+        )
+    else:
+        return _fetch_geometry_low_rank(
+            mesh=mesh,
+            resolution=resolution,
+            method=method,
+            rank=rank,
+            n_landmarks=n_landmarks,
+            n_jobs=n_jobs,
+            verbose=verbose,
+        )

--- a/src/fugw/datasets/vol_geometry.py
+++ b/src/fugw/datasets/vol_geometry.py
@@ -51,9 +51,10 @@ def _fetch_geometry_full_rank(
         geometry = distance_matrix(coordinates, coordinates)
 
     # Normalize the distance matrix
-    geometry = geometry / geometry.max()
+    d_max = geometry.max()
+    geometry = geometry / d_max
 
-    return geometry
+    return geometry, d_max
 
 
 @memory.cache

--- a/src/fugw/datasets/vol_geometry.py
+++ b/src/fugw/datasets/vol_geometry.py
@@ -1,0 +1,123 @@
+import numpy as np
+
+from typing import Tuple, Any
+
+from joblib import Memory
+from nilearn import datasets, masking
+from scipy.spatial import distance_matrix
+
+from fugw.scripts import coarse_to_fine, lmds
+
+
+# Create a Memory object to handle the caching
+fugw_data = "~/fugw_data"
+memory = Memory(fugw_data, verbose=0)
+
+
+def _check_masker(mask: str) -> None:
+    valid_masks = ["mni152_gm_mask", "mni152_brain_mask"]
+    if mask not in valid_masks:
+        raise ValueError(
+            f"Unknown mask {mask}. Valid masks include {valid_masks}."
+        )
+
+
+def _compute_connected_segmentation(mask_img: Any) -> np.ndarray:
+    return (
+        masking.compute_background_mask(mask_img, connected=True).get_fdata()
+        > 0
+    )
+
+
+@memory.cache
+def _fetch_geometry_full_rank(
+    mask: str, resolution: int, method: str = "euclidean"
+):
+    if mask == "mni152_gm_mask":
+        mask_img = datasets.load_mni152_gm_mask(resolution=resolution)
+    elif mask == "mni152_brain_mask":
+        mask_img = datasets.load_mni152_brain_mask(resolution=resolution)
+    segmentation = _compute_connected_segmentation(mask_img)
+
+    if method == "geodesic":
+        raise NotImplementedError(
+            "Geodesic distance computation is not implemented for volume data"
+            " in the full-rank setting."
+        )
+
+    elif method == "euclidean":
+        # Return euclidean distance matrix
+        coordinates = np.array(np.where(segmentation)).T
+        geometry = distance_matrix(coordinates, coordinates)
+
+    # Normalize the distance matrix
+    geometry = geometry / geometry.max()
+
+    return geometry
+
+
+@memory.cache
+def _fetch_geometry_low_rank(
+    mask: str,
+    resolution: str,
+    method: str = "euclidean",
+    rank: int = 3,
+    n_landmarks: int = 100,
+    n_jobs: int = 2,
+    verbose: bool = True,
+) -> Tuple[np.ndarray, float]:
+    if mask == "mni152_gm_mask":
+        mask_img = datasets.load_mni152_gm_mask(resolution=resolution)
+    elif mask == "mni152_brain_mask":
+        mask_img = datasets.load_mni152_brain_mask(resolution=resolution)
+    segmentation = _compute_connected_segmentation(mask_img)
+
+    # Get the anisotropy of the 3D mask
+    anisotropy = np.abs(mask_img.header.get_zooms()[:3]).tolist()
+
+    geometry_embedding = lmds.compute_lmds_volume(
+        segmentation,
+        method=method,
+        k=rank,
+        n_landmarks=n_landmarks,
+        anisotropy=anisotropy,
+        n_jobs=n_jobs,
+        verbose=verbose,
+    ).nan_to_num()
+
+    (
+        geometry_embedding_normalized,
+        d_max,
+    ) = coarse_to_fine.random_normalizing(geometry_embedding)
+
+    return (
+        geometry_embedding_normalized.cpu().numpy(),
+        d_max,
+    )
+
+
+def fetch_vol_geometry(
+    mask: str,
+    resolution: int,
+    method: str = "euclidean",
+    rank: int = -1,
+    n_landmarks: int = 100,
+    n_jobs: int = 2,
+    verbose: bool = True,
+):
+    _check_masker(mask)
+
+    if rank == -1:
+        return _fetch_geometry_full_rank(
+            mask=mask, resolution=resolution, method=method
+        )
+    else:
+        return _fetch_geometry_low_rank(
+            mask=mask,
+            resolution=resolution,
+            method=method,
+            rank=rank,
+            n_landmarks=n_landmarks,
+            n_jobs=n_jobs,
+            verbose=verbose,
+        )

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -1,7 +1,7 @@
 import torch
 
 from fugw.mappings.dense import FUGW
-from fugw.utils import _make_tensor
+from fugw.utils import _make_tensor, console
 
 
 class FUGWBarycenter:
@@ -131,6 +131,9 @@ class FUGWBarycenter:
         for i, (features, weights) in enumerate(
             zip(features_list, weights_list)
         ):
+            if verbose:
+                console.log(f"Updating mapping {i + 1} / {len(weights_list)}")
+
             if len(geometry_list) == 1 and len(weights_list) > 1:
                 G = geometry_list[0]
             else:
@@ -278,6 +281,10 @@ class FUGWBarycenter:
         losses_each_bar_step = []
 
         for idx in range(nits_barycenter):
+            if verbose:
+                console.log(
+                    f"Barycenter iterations {idx + 1} / {nits_barycenter}"
+                )
             # Transport all elements
             plans, losses = self.compute_all_ot_plans(
                 plans,

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -93,6 +93,12 @@ class FUGWBarycenter:
                 else:
                     barycenter_features += acc
 
+        # Normalize barycenter features
+        min_val = barycenter_features.min(dim=0, keepdim=True).values
+        max_val = barycenter_features.max(dim=0, keepdim=True).values
+        barycenter_features = (
+            2 * (barycenter_features - min_val) / (max_val - min_val) - 1
+        )
         return barycenter_features.T
 
     @staticmethod

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -3,7 +3,7 @@ import torch
 from fugw.mappings.dense import FUGW
 from fugw.mappings.sparse import FUGWSparse
 from fugw.scripts import coarse_to_fine
-from fugw.utils import _make_tensor
+from fugw.utils import _make_tensor, console
 
 
 class FUGWSparseBarycenter:
@@ -91,6 +91,9 @@ class FUGWSparseBarycenter:
         for i, (features, weights) in enumerate(
             zip(features_list, weights_list)
         ):
+            if verbose:
+                console.log(f"Updating mapping {i + 1} / {len(weights_list)}")
+
             coarse_mapping = FUGW(
                 alpha=self.alpha_coarse,
                 rho=self.rho_coarse,
@@ -255,6 +258,11 @@ class FUGWSparseBarycenter:
         losses_each_bar_step = []
 
         for idx in range(nits_barycenter):
+            if verbose:
+                console.log(
+                    f"Barycenter iterations {idx + 1} / {nits_barycenter}"
+                )
+
             # Transport all elements
             plans, losses, sparsity_mask = self.compute_all_ot_plans(
                 plans,

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -81,7 +81,7 @@ class FUGWSparseBarycenter:
         coarse_mapping_solver_params,
         fine_mapping_solver_params,
         selection_radius,
-        mask,
+        sparsity_mask,
         device,
         verbose,
     ):
@@ -105,7 +105,7 @@ class FUGWSparseBarycenter:
                 reg_mode=self.reg_mode,
             )
 
-            _, _, mask = coarse_to_fine.fit(
+            _, _, sparsity_mask = coarse_to_fine.fit(
                 source_features=features,
                 target_features=barycenter_features,
                 source_geometry_embeddings=geometry_embedding,
@@ -124,7 +124,7 @@ class FUGWSparseBarycenter:
                 fine_mapping_solver=solver,
                 fine_mapping_solver_params=fine_mapping_solver_params,
                 init_plan=plans[i] if plans is not None else None,
-                mask=mask,
+                sparsity_mask=sparsity_mask,
                 device=device,
                 verbose=verbose,
             )
@@ -251,7 +251,7 @@ class FUGWSparseBarycenter:
             )
 
         plans = None
-        mask = None
+        sparsity_mask = None
         losses_each_bar_step = []
 
         for idx in range(nits_barycenter):
@@ -268,7 +268,7 @@ class FUGWSparseBarycenter:
                 coarse_mapping_solver_params,
                 fine_mapping_solver_params,
                 self.selection_radius,
-                mask,
+                sparsity_mask,
                 device,
                 verbose,
             )

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -140,7 +140,7 @@ class FUGWSparseBarycenter:
                 )
             )
 
-        return new_plans, new_losses
+        return new_plans, new_losses, sparsity_mask
 
     def fit(
         self,
@@ -256,7 +256,7 @@ class FUGWSparseBarycenter:
 
         for idx in range(nits_barycenter):
             # Transport all elements
-            plans, losses = self.compute_all_ot_plans(
+            plans, losses, sparsity_mask = self.compute_all_ot_plans(
                 plans,
                 weights_list,
                 features_list,

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -52,6 +52,12 @@ class FUGWSparseBarycenter:
                 else:
                     barycenter_features += acc
 
+        # Normalize barycenter features
+        min_val = barycenter_features.min(dim=0, keepdim=True).values
+        max_val = barycenter_features.max(dim=0, keepdim=True).values
+        barycenter_features = (
+            2 * (barycenter_features - min_val) / (max_val - min_val) - 1
+        )
         return barycenter_features.T
 
     @staticmethod

--- a/src/fugw/scripts/coarse_to_fine.py
+++ b/src/fugw/scripts/coarse_to_fine.py
@@ -309,9 +309,7 @@ def compute_sparsity_mask(
     """
     if method == "quantile":
         # Method 1: keep first percentile
-        quantile = 99.95
-
-        threshold = np.percentile(coarse_mapping.pi, quantile)
+        threshold = np.percentile(coarse_mapping.pi, 99.95)
         rows, cols = np.nonzero(coarse_mapping.pi > threshold)
 
     elif method == "topk":

--- a/src/fugw/scripts/coarse_to_fine.py
+++ b/src/fugw/scripts/coarse_to_fine.py
@@ -264,6 +264,90 @@ def get_neighbourhood_matrix(embeddings, sample, radius):
     return neighbourhood_matrix
 
 
+def compute_sparsity_mask(
+    coarse_mapping,
+    source_sample,
+    target_sample,
+    source_geometry_embeddings,
+    target_geometry_embeddings,
+    source_selection_radius=1,
+    target_selection_radius=1,
+    method="topk",
+):
+    """
+    Compute sparsity mask from coarse mapping.
+
+    Parameters
+    ----------
+    coarse_mapping: fugw.FUGW
+        Dense mapping between subsampled meshes
+    source_sample: torch.Tensor of size (n1)
+        Indices of sampled points on source distribution
+    target_sample: torch.Tensor of size (m1)
+        Indices of sampled points on target distribution
+    source_geometry_embeddings: torch.Tensor of size (n, k)
+        Embeddings approximating the geodesic distance between
+        source vertices
+    target_geometry_embeddings: torch.Tensor of size (m, k)
+        Embeddings approximating the geodesic distance between
+        target vertices
+    source_selection_radius: float
+        Radius used to determine the neighbourhood
+        of source vertices when defining sparsity mask
+    target_selection_radius: float
+        Radius used to determine the neighbourhood
+        of target vertices when defining sparsity mask
+    method: "topk" or "quantile"
+        Method used to select pairs of source and target features
+        whose neighbourhoods will be used to define
+        the sparsity mask of the solution
+
+    Returns
+    -------
+    sparsity_mask: torch.sparse_coo_tensor of size (n, m)
+        Sparsity mask used to initialize the fine mapping.
+    """
+    if method == "quantile":
+        # Method 1: keep first percentile
+        quantile = 99.95
+
+        threshold = np.percentile(coarse_mapping.pi, quantile)
+        rows, cols = np.nonzero(coarse_mapping.pi > threshold)
+
+    elif method == "topk":
+        # Method 2: keep topk indices per line and per column
+        # (this should be preferred as it will keep vertices
+        # which are particularly unbalanced)
+        rows = np.concatenate(
+            [
+                np.arange(source_sample.shape[0]),
+                np.argmax(coarse_mapping.pi, axis=0),
+            ]
+        )
+        cols = np.concatenate(
+            [
+                np.argmax(coarse_mapping.pi, axis=1),
+                np.arange(target_sample.shape[0]),
+            ]
+        )
+
+    # Compute mask as a matrix product between:
+    # a. neighbourhood matrices that encode
+    # which vertex is close to which sampled point
+    N_source = get_neighbourhood_matrix(
+        source_geometry_embeddings, source_sample, source_selection_radius
+    )
+    N_target = get_neighbourhood_matrix(
+        target_geometry_embeddings, target_sample, target_selection_radius
+    )
+    # b. cluster matrices that encode
+    # which sampled point belongs to which cluster
+    C_source = get_cluster_matrix(rows, source_sample.shape[0])
+    C_target = get_cluster_matrix(cols, target_sample.shape[0])
+
+    return (N_source @ C_source) @ (N_target @ C_target).T
+
+
 def fit(
     coarse_mapping=None,
     coarse_mapping_solver="mm",
@@ -285,7 +369,7 @@ def fit(
     source_weights=None,
     target_weights=None,
     init_plan=None,
-    mask=None,
+    sparsity_mask=None,
     device="auto",
     verbose=False,
 ):
@@ -353,7 +437,7 @@ def fit(
     init_plan: torch.sparse_coo_tensor or None
         Initial transport plan to use when fitting the fine mapping.
         If None, a random plan will be used.
-    sparsity_mask: torch.Tensor of size(n, m) or None
+    sparsity_mask: sparse coo/csr matrix of size(n, m) or None
         Sparsity mask to use when fitting the fine mapping.
         If None, a mask will be computed from the coarse mapping.
     device: "auto" or torch.device
@@ -374,28 +458,11 @@ def fit(
         Sparsity mask used to fit the fine mapping.
     """
     # 0. Parse input tensors
-    source_sample = _make_tensor(source_sample, dtype=torch.int64)
-    target_sample = _make_tensor(target_sample, dtype=torch.int64)
-
     source_features = _make_tensor(source_features)
     target_features = _make_tensor(target_features)
 
     source_geometry_embeddings = _make_tensor(source_geometry_embeddings)
     target_geometry_embeddings = _make_tensor(target_geometry_embeddings)
-
-    # Compute anatomical kernels
-    source_geometry_kernel = torch.cdist(
-        source_geometry_embeddings[source_sample],
-        source_geometry_embeddings[source_sample],
-        p=2,
-    )
-    source_geometry_kernel /= source_geometry_kernel.max()
-    target_geometry_kernel = torch.cdist(
-        target_geometry_embeddings[target_sample],
-        target_geometry_embeddings[target_sample],
-        p=2,
-    )
-    target_geometry_kernel /= target_geometry_kernel.max()
 
     # Sampled weights
     if source_weights is None:
@@ -405,79 +472,66 @@ def fit(
         m = target_features.shape[1]
         target_weights = torch.ones(m) / m
 
-    source_weights_sampled = _make_tensor(source_weights)[source_sample]
-    source_weights_sampled = (
-        source_weights_sampled / source_weights_sampled.sum()
-    )
-    target_weights_sampled = _make_tensor(target_weights)[target_sample]
-    target_weights_sampled = (
-        target_weights_sampled / target_weights_sampled.sum()
-    )
+    if sparsity_mask is None:
+        source_sample = _make_tensor(source_sample, dtype=torch.int64)
+        target_sample = _make_tensor(target_sample, dtype=torch.int64)
 
-    # 1. Fit coarse mapping
-    coarse_mapping.fit(
-        source_features[:, source_sample],
-        target_features[:, target_sample],
-        source_geometry=source_geometry_kernel,
-        target_geometry=target_geometry_kernel,
-        source_weights=source_weights_sampled,
-        target_weights=target_weights_sampled,
-        solver=coarse_mapping_solver,
-        solver_params=coarse_mapping_solver_params,
-        callback_bcd=coarse_callback_bcd,
-        device=device,
-        verbose=verbose,
-    )
-
-    # 2. Build sparsity mask
-
-    # Select best pairs of source and target vertices from coarse alignment
-    if coarse_pairs_selection_method == "quantile":
-        # Method 1: keep first percentile
-        quantile = 99.95
-
-        threshold = np.percentile(coarse_mapping.pi, quantile)
-        rows, cols = np.nonzero(coarse_mapping.pi > threshold)
-
-    elif coarse_pairs_selection_method == "topk":
-        # Method 2: keep topk indices per line and per column
-        # (this should be preferred as it will keep vertices
-        # which are particularly unbalanced)
-        rows = np.concatenate(
-            [
-                np.arange(source_sample.shape[0]),
-                np.argmax(coarse_mapping.pi, axis=0),
-            ]
+        source_weights_sampled = _make_tensor(source_weights)[source_sample]
+        source_weights_sampled = (
+            source_weights_sampled / source_weights_sampled.sum()
         )
-        cols = np.concatenate(
-            [
-                np.argmax(coarse_mapping.pi, axis=1),
-                np.arange(target_sample.shape[0]),
-            ]
+        target_weights_sampled = _make_tensor(target_weights)[target_sample]
+        target_weights_sampled = (
+            target_weights_sampled / target_weights_sampled.sum()
         )
 
-    if mask is None:
-        # Compute mask as a matrix product between:
-        # a. neighbourhood matrices that encode
-        # which vertex is close to which sampled point
-        N_source = get_neighbourhood_matrix(
-            source_geometry_embeddings, source_sample, source_selection_radius
+        # Compute anatomical kernels
+        source_geometry_kernel = torch.cdist(
+            source_geometry_embeddings[source_sample],
+            source_geometry_embeddings[source_sample],
+            p=2,
         )
-        N_target = get_neighbourhood_matrix(
-            target_geometry_embeddings, target_sample, target_selection_radius
+        source_geometry_kernel /= source_geometry_kernel.max()
+        target_geometry_kernel = torch.cdist(
+            target_geometry_embeddings[target_sample],
+            target_geometry_embeddings[target_sample],
+            p=2,
         )
-        # b. cluster matrices that encode
-        # which sampled point belongs to which cluster
-        C_source = get_cluster_matrix(rows, source_sample.shape[0])
-        C_target = get_cluster_matrix(cols, target_sample.shape[0])
+        target_geometry_kernel /= target_geometry_kernel.max()
 
-        mask = (N_source @ C_source) @ (N_target @ C_target).T
+        # 1. Fit coarse mapping
+        coarse_mapping.fit(
+            source_features[:, source_sample],
+            target_features[:, target_sample],
+            source_geometry=source_geometry_kernel,
+            target_geometry=target_geometry_kernel,
+            source_weights=source_weights_sampled,
+            target_weights=target_weights_sampled,
+            solver=coarse_mapping_solver,
+            solver_params=coarse_mapping_solver_params,
+            callback_bcd=coarse_callback_bcd,
+            device=device,
+            verbose=verbose,
+        )
+
+        # 2. Build sparsity mask
+        sparsity_mask = compute_sparsity_mask(
+            coarse_mapping,
+            source_sample,
+            target_sample,
+            source_geometry_embeddings,
+            target_geometry_embeddings,
+            source_selection_radius=source_selection_radius,
+            target_selection_radius=target_selection_radius,
+            method=coarse_pairs_selection_method,
+        )
 
     # Define init plan from spasity mask
     if init_plan is None:
         init_plan = torch.sparse_coo_tensor(
-            mask.indices(),
-            torch.ones_like(mask.values()) / mask.values().shape[0],
+            sparsity_mask.indices(),
+            torch.ones_like(sparsity_mask.values())
+            / sparsity_mask.values().shape[0],
             (
                 source_geometry_embeddings.shape[0],
                 target_geometry_embeddings.shape[0],
@@ -501,4 +555,4 @@ def fit(
         storing_device=device,
     )
 
-    return source_sample, target_sample, mask
+    return source_sample, target_sample, sparsity_mask

--- a/tests/datasets/test_surf_geometry.py
+++ b/tests/datasets/test_surf_geometry.py
@@ -47,8 +47,9 @@ def test_check_resolution():
 def test_fetch_geometry_full_rank(mesh, method):
     resolution = "fsaverage3"
     n_vertices = 642  # fsaverage3 has 642 vertices
-    geometry = _fetch_geometry_full_rank(mesh, resolution, method)
+    geometry, d_max = _fetch_geometry_full_rank(mesh, resolution, method)
 
+    assert isinstance(d_max, float)
     assert isinstance(geometry, np.ndarray)
     assert geometry.shape == (n_vertices, n_vertices)
 
@@ -83,8 +84,9 @@ def test_fetch_surf_geometry(mesh):
     n_vertices = 642
 
     rank = -1
-    geometry = fetch_surf_geometry(mesh, resolution, rank=rank)
+    geometry, d_max = fetch_surf_geometry(mesh, resolution, rank=rank)
 
+    assert isinstance(d_max, float)
     assert isinstance(geometry, np.ndarray)
     assert geometry.shape == (n_vertices, n_vertices)
 

--- a/tests/datasets/test_surf_geometry.py
+++ b/tests/datasets/test_surf_geometry.py
@@ -1,0 +1,99 @@
+from itertools import product
+
+import numpy as np
+import pytest
+
+from fugw.datasets.surf_geometry import (
+    fetch_surf_geometry,
+    _check_mesh,
+    _check_resolution,
+    _fetch_geometry_full_rank,
+    _fetch_geometry_low_rank,
+)
+
+valid_surf_meshes = [
+    "pial_left",
+    "pial_right",
+    "infl_left",
+    "infl_right",
+]
+
+
+def test_check_mesh():
+    valid_mesh = valid_surf_meshes[0]
+    invalid_mesh = "pial"
+
+    assert _check_mesh(valid_mesh) is None
+    with pytest.raises(ValueError):
+        _check_mesh(invalid_mesh)
+
+
+def test_check_resolution():
+    valid_resolution = "fsaverage3"
+    invalid_resolution = "fsaverage1"
+
+    assert _check_resolution(valid_resolution) is None
+    with pytest.raises(ValueError):
+        _check_resolution(invalid_resolution)
+
+
+@pytest.mark.parametrize(
+    "mesh,method",
+    product(
+        valid_surf_meshes,
+        ["geodesic", "euclidean"],
+    ),
+)
+def test_fetch_geometry_full_rank(mesh, method):
+    resolution = "fsaverage3"
+    n_vertices = 642  # fsaverage3 has 642 vertices
+    geometry = _fetch_geometry_full_rank(mesh, resolution, method)
+
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_vertices, n_vertices)
+
+
+@pytest.mark.parametrize(
+    "mesh,method,rank,n_landmarks",
+    product(
+        valid_surf_meshes,
+        ["geodesic"],
+        [3],
+        [100],
+    ),
+)
+def test_fetch_geometry_low_rank(mesh, method, rank, n_landmarks):
+    resolution = "fsaverage3"
+    n_vertices = 642  # fsaverage3 has 642 vertices
+    geometry, d_max = _fetch_geometry_low_rank(
+        mesh, resolution, method, rank, n_landmarks, verbose=False
+    )
+
+    assert isinstance(d_max, float)
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_vertices, rank)
+
+
+@pytest.mark.parametrize(
+    "mesh",
+    valid_surf_meshes,
+)
+def test_fetch_surf_geometry(mesh):
+    resolution = "fsaverage3"
+    n_vertices = 642
+
+    rank = -1
+    geometry = fetch_surf_geometry(mesh, resolution, rank=rank)
+
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_vertices, n_vertices)
+
+    rank = 3
+    n_landmarks = 100
+    geometry, d_max = fetch_surf_geometry(
+        mesh, resolution, rank=rank, n_landmarks=n_landmarks, verbose=False
+    )
+
+    assert isinstance(d_max, float)
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_vertices, rank)

--- a/tests/datasets/test_vol_geometry.py
+++ b/tests/datasets/test_vol_geometry.py
@@ -27,8 +27,11 @@ def test_fetch_geometry_full_rank():
     mask = "mni152_gm_mask"
     resolution = 10
     n_voxels = 1886  # Number of voxels in the mask
-    geometry = _fetch_geometry_full_rank(mask, resolution, method="euclidean")
+    geometry, d_max = _fetch_geometry_full_rank(
+        mask, resolution, method="euclidean"
+    )
 
+    assert isinstance(d_max, float)
     assert isinstance(geometry, np.ndarray)
     assert geometry.shape == (n_voxels, n_voxels)
 
@@ -57,8 +60,9 @@ def test_fetch_vol_geometry():
     n_voxels = 1886  # Number of voxels in the mask
 
     rank = -1
-    geometry = fetch_vol_geometry(mask, resolution, rank=rank)
+    geometry, d_max = fetch_vol_geometry(mask, resolution, rank=rank)
 
+    assert isinstance(d_max, float)
     assert isinstance(geometry, np.ndarray)
     assert geometry.shape == (n_voxels, n_voxels)
 

--- a/tests/datasets/test_vol_geometry.py
+++ b/tests/datasets/test_vol_geometry.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from fugw.datasets.vol_geometry import (
+    fetch_vol_geometry,
+    _check_masker,
+    _fetch_geometry_full_rank,
+    _fetch_geometry_low_rank,
+)
+
+valid_masks = [
+    "mni152_gm_mask",
+    "mni152_brain_mask",
+]
+
+
+def test_check_mesh():
+    valid_mask = valid_masks[0]
+    invalid_mask = "mni200"
+
+    assert _check_masker(valid_mask) is None
+    with pytest.raises(ValueError):
+        _check_masker(invalid_mask)
+
+
+def test_fetch_geometry_full_rank():
+    mask = "mni152_gm_mask"
+    resolution = 10
+    n_voxels = 1886  # Number of voxels in the mask
+    geometry = _fetch_geometry_full_rank(mask, resolution, method="euclidean")
+
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_voxels, n_voxels)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["geodesic", "euclidean"],
+)
+def test_fetch_geometry_low_rank(method):
+    mask = "mni152_gm_mask"
+    resolution = 10
+    n_voxels = 1886  # Number of voxels in the mask
+    rank = 3
+    geometry, d_max = _fetch_geometry_low_rank(
+        mask, resolution, method, rank, verbose=False
+    )
+
+    assert isinstance(d_max, float)
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_voxels, rank)
+
+
+def test_fetch_vol_geometry():
+    mask = "mni152_gm_mask"
+    resolution = 10
+    n_voxels = 1886  # Number of voxels in the mask
+
+    rank = -1
+    geometry = fetch_vol_geometry(mask, resolution, rank=rank)
+
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_voxels, n_voxels)
+
+    rank = 3
+    geometry, d_max = fetch_vol_geometry(
+        mask, resolution, rank=rank, verbose=False
+    )
+
+    assert isinstance(d_max, float)
+    assert isinstance(geometry, np.ndarray)
+    assert geometry.shape == (n_voxels, rank)


### PR DESCRIPTION
The following PR implements unified geometry fetchers for common brain spaces with a caching system. Geometric embeddings can be retrieved in their full-rank or low-rank form.

For surfaces:

- fsaverage3
- fsaverage4
- fsaverage5
- fsaverage6
- fsaverage7
- fsaverage

For volumes:
- mni152_gm_mask
- mni152_brain_mask

TODOs:

- [x] Docstrings
- [x] Unit tests