### PR TITLE
[FIX] Improve CI speed by explicitely installing torch cpu only

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -20,6 +20,7 @@ jobs:
           pre-build-command: |
             apt-get update
             pip install -U pip
+            pip install torch --index-url https://download.pytorch.org/whl/cpu
             pip install -e ".[doc]"
       - name: Upload generated HTML as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install -e .[test]
       - name: Lint with pflake8
         run: |

--- a/src/fugw/mappings/sparse.py
+++ b/src/fugw/mappings/sparse.py
@@ -124,7 +124,6 @@ class FUGWSparse(BaseMapping):
                 device = torch.device("cuda", 0)
             else:
                 device = torch.device("cpu")
-            storing_device = device
 
         if isinstance(self.rho, float) or isinstance(self.rho, int):
             rho_s = self.rho

--- a/src/fugw/scripts/coarse_to_fine.py
+++ b/src/fugw/scripts/coarse_to_fine.py
@@ -501,7 +501,6 @@ def fit(
         solver=fine_mapping_solver,
         solver_params=fine_mapping_solver_params,
         callback_bcd=fine_callback_bcd,
-        storing_device=device,
     )
 
     return source_sample, target_sample, mask


### PR DESCRIPTION
Speeds up the CI runtime by explicitely installing the cpu-only version of torch and not the cuda libraries.