### PR TITLE
[BUGFIX] Fix dense barycenter calculations

### DIFF
--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -79,11 +79,12 @@ class FUGWBarycenter:
         return barycenter_geometry
 
     @staticmethod
-    def update_barycenter_features(plans, weights_list, features_list, device):
-        for i, (pi, weights, features) in enumerate(
-            zip(plans, weights_list, features_list)
+    def update_barycenter_features(
+        plans, subject_weights, features_list, device
+    ):
+        for i, (pi, w, features) in enumerate(
+            zip(plans, subject_weights, features_list)
         ):
-            w = _make_tensor(weights, device=device)
             f = _make_tensor(features, device=device)
             if features is not None:
                 acc = w * pi.T @ f.T / (pi.sum(0).reshape(-1, 1) + 1e-16)
@@ -93,12 +94,6 @@ class FUGWBarycenter:
                 else:
                     barycenter_features += acc
 
-        # Normalize barycenter features
-        min_val = barycenter_features.min(dim=0, keepdim=True).values
-        max_val = barycenter_features.max(dim=0, keepdim=True).values
-        barycenter_features = (
-            2 * (barycenter_features - min_val) / (max_val - min_val) - 1
-        )
         return barycenter_features.T
 
     @staticmethod

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -271,7 +271,12 @@ class FUGWBarycenter:
                 init_barycenter_features, device=device
             )
 
-        if init_barycenter_geometry is None:
+        if init_barycenter_geometry is None and self.learn_geometry is False:
+            raise ValueError(
+                "In the fixed support case, init_barycenter_geometry must be"
+                " provided."
+            )
+        elif init_barycenter_geometry is None and self.learn_geometry is True:
             barycenter_geometry = (
                 torch.ones((barycenter_size, barycenter_size)).to(device)
                 / barycenter_size

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -11,7 +11,7 @@ class FUGWBarycenter:
         self,
         alpha=0.5,
         rho=1,
-        eps=1e-2,
+        eps=1e-4,
         reg_mode="joint",
         force_psd=False,
         learn_geometry=False,

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -122,7 +122,6 @@ class FUGWBarycenter:
         barycenter_geometry,
         solver,
         solver_params,
-        callback_barycenter,
         device,
         verbose,
     ):
@@ -309,7 +308,6 @@ class FUGWBarycenter:
                 barycenter_geometry,
                 solver,
                 solver_params,
-                callback_barycenter,
                 device,
                 verbose,
             )

--- a/src/fugw/mappings/barycenter.py
+++ b/src/fugw/mappings/barycenter.py
@@ -178,6 +178,7 @@ class FUGWBarycenter:
         weights_list,
         features_list,
         geometry_list,
+        subject_weights=None,
         barycenter_size=None,
         init_barycenter_weights=None,
         init_barycenter_features=None,
@@ -204,6 +205,9 @@ class FUGWBarycenter:
             or just one kernel matrix if it's shared across individuals
             barycenter_size (int, optional): Size of computed
             barycentric features and geometry. Defaults to None.
+        subject_weights (list of float, optional): Weights of each individual.
+            If None, all individuals will have the same weight.
+            Defaults to None.
         init_barycenter_weights (np.array, optional): Distribution weights
             of barycentric points. If None, points will have uniform
             weights. Defaults to None.
@@ -281,6 +285,9 @@ class FUGWBarycenter:
                 init_barycenter_geometry, device=device
             )
 
+        if subject_weights is None:
+            subject_weights = [1 / len(weights_list)] * len(weights_list)
+
         plans = None
         duals = None
         losses_each_bar_step = []
@@ -311,7 +318,7 @@ class FUGWBarycenter:
 
             # Update barycenter features and geometry
             barycenter_features = self.update_barycenter_features(
-                plans, weights_list, features_list, device
+                plans, subject_weights, features_list, device
             )
             if self.learn_geometry:
                 barycenter_geometry = self.update_barycenter_geometry(

--- a/src/fugw/mappings/sparse_barycenter.py
+++ b/src/fugw/mappings/sparse_barycenter.py
@@ -33,11 +33,12 @@ class FUGWSparseBarycenter:
         self.selection_radius = selection_radius
 
     @staticmethod
-    def update_barycenter_features(plans, weights_list, features_list, device):
-        for i, (pi, weights, features) in enumerate(
-            zip(plans, weights_list, features_list)
+    def update_barycenter_features(
+        plans, subject_weights, features_list, device
+    ):
+        for i, (pi, w, features) in enumerate(
+            zip(plans, subject_weights, features_list)
         ):
-            w = _make_tensor(weights, device=device)
             f = _make_tensor(features, device=device)
 
             if features is not None:
@@ -156,6 +157,7 @@ class FUGWSparseBarycenter:
         weights_list,
         features_list,
         geometry_embedding,
+        subject_weights=None,
         barycenter_size=None,
         init_barycenter_weights=None,
         init_barycenter_features=None,
@@ -181,6 +183,9 @@ class FUGWSparseBarycenter:
             have the same number of features n_features.
         geometry_embedding (np.array or torch.Tensor): Common geometry
             embedding of all individuals and barycenter.
+        subject_weights (list of float, optional): Weights of each individual.
+            If None, all individuals will have the same weight.
+            Defaults to None.
         barycenter_size (int), optional:
             Size of computed barycentric features and geometry.
             Defaults to None.
@@ -259,6 +264,9 @@ class FUGWSparseBarycenter:
                 geometry_embedding, device=device
             )
 
+        if subject_weights is None:
+            subject_weights = [1 / len(weights_list)] * len(weights_list)
+
         plans = None
         sparsity_mask = None
         losses_each_bar_step = []
@@ -291,7 +299,7 @@ class FUGWSparseBarycenter:
 
             # Update barycenter features and geometry
             barycenter_features = self.update_barycenter_features(
-                plans, weights_list, features_list, device
+                plans, subject_weights, features_list, device
             )
 
             if callback_barycenter is not None:

--- a/tests/mappings/test_barycenter.py
+++ b/tests/mappings/test_barycenter.py
@@ -58,6 +58,7 @@ def test_fugw_barycenter(device, callback):
         nits_barycenter=nits_barycenter,
         device=device,
         callback_barycenter=callback,
+        init_barycenter_geometry=geometry_list[0],
     )
 
     assert isinstance(barycenter_weights, torch.Tensor)
@@ -76,14 +77,14 @@ def test_fugw_barycenter(device, callback):
 )
 def test_identity_case(alpha):
     """Test the case where all subjects are the same."""
+    torch.manual_seed(0)
     n_subjects = 3
     n_features = 10
     n_voxels = 5
     nits_barycenter = 2
 
     geometry = _init_mock_distribution(n_features, n_voxels)[2]
-    # features = torch.rand(n_features, n_voxels)
-    features = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]])
+    features = torch.rand(n_features, n_voxels)
 
     geometry_list = [geometry for _ in range(n_subjects)]
     features_list = [features for _ in range(n_subjects)]
@@ -109,7 +110,6 @@ def test_identity_case(alpha):
     )
 
     # Check that the barycenter is the same as the input
-    print(barycenter_features)
     assert torch.allclose(barycenter_weights, torch.ones(n_voxels) / n_voxels)
     assert torch.allclose(barycenter_geometry, geometry_list[0])
 
@@ -117,8 +117,7 @@ def test_identity_case(alpha):
     # since the GW distance is invariant under isometries
     if alpha != 1.0:
         assert torch.allclose(barycenter_features, features)
-
-    # Check that all the plans are the identity matrix divided
-    # by the number of voxels
-    for plan in plans:
-        assert torch.allclose(plan, torch.eye(n_voxels) / n_voxels)
+        # Check that all the plans are the identity matrix divided
+        # by the number of voxels
+        for plan in plans:
+            assert torch.allclose(plan, torch.eye(n_voxels) / n_voxels)

--- a/tests/mappings/test_barycenter.py
+++ b/tests/mappings/test_barycenter.py
@@ -80,7 +80,7 @@ def test_identity_case(alpha):
     torch.manual_seed(0)
     n_subjects = 3
     n_features = 10
-    n_voxels = 5
+    n_voxels = 100
     nits_barycenter = 2
 
     geometry = _init_mock_distribution(n_features, n_voxels)[2]


### PR DESCRIPTION
Solves #58, #77 and #78.

Adds a new set of tests against POT and in the identity case. Fixes the barycenter weight mix-up issue in the dense case.
It might be worth opening another PR for the sparse case.