### PR TITLE
Drop python 3.8 from CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version_python: "3.8"
-          - os: ubuntu-latest
             version_python: "3.9"
           - os: ubuntu-latest
             version_python: "3.10"


### PR DESCRIPTION
Closes #85.